### PR TITLE
Minor change to displaying the network

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -7,8 +7,9 @@
           margin: 0;
         }
         #graph {
-          width: 300px;
+          width: 600px;
           height: 300px;
+          margin: auto;
         }
       </style>
       <h1><%= @collection.title %></h1>


### PR DESCRIPTION
These networks are so beautiful, I thought we could make them a bit bigger. I've tweaked the margin and doubled the width.

Example:

**On iPad Mini**
![screen shot 2018-03-07 at 10 36 47 pm](https://user-images.githubusercontent.com/3834704/37131788-2938a53a-2258-11e8-82e9-0833b76128ce.png)

**On laptop**
![screen shot 2018-03-07 at 10 36 56 pm](https://user-images.githubusercontent.com/3834704/37131798-320e501a-2258-11e8-8f47-bc4bfb16093a.png)

**And on high-rez screen**
![screen shot 2018-03-07 at 10 37 00 pm](https://user-images.githubusercontent.com/3834704/37131803-414d2dd0-2258-11e8-815c-98e975b4b5cd.png)
